### PR TITLE
feat: implement group creation and fetch with auth and Swagger docs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import swaggerUi from 'swagger-ui-express';
 import todoRoutes from './routes/todoRoutes';
 import taskRoutes from './routes/taskRoutes';
 import paymentRoutes from './routes/paymentRoutes';
+import groupRoutes from './routes/groupRoutes';
 import { schema } from './graphql/schema';
 import { resolvers } from './graphql/resolvers';
 import { swaggerSpec } from './docs/swagger';
@@ -31,6 +32,7 @@ app.use(express.json());
 app.use('/api/v1/todos', todoRoutes);
 app.use('/api/v1/tasks', taskRoutes);
 app.use('/api/v1/payments', paymentRoutes);
+app.use('/api/v1/groups', groupRoutes);
 
 // Swagger documentation
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/src/controllers/groupController.ts
+++ b/src/controllers/groupController.ts
@@ -1,0 +1,47 @@
+import { Response } from 'express';
+import { AuthRequest } from '../types/express';
+import * as groupService from '../services/groupService';
+
+export const createGroup = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.user?.userId;
+    const { groupName, groupDescription, groupAdministrator } = req.body;
+
+    if (!userId) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+
+    if (!groupName) {
+      res.status(400).json({ message: 'Group name is required' });
+      return;
+    }
+
+    const group = await groupService.createGroup(
+      { groupName, groupDescription, groupAdministrator },
+      userId
+    );
+
+    res.status(201).json({ success: true, data: group });
+  } catch (error) {
+    console.error('Create Group Error:', error);
+    res.status(500).json({ success: false, message: 'Internal Server Error' });
+  }
+};
+
+export const getGroups = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+
+    const groups = await groupService.getGroups(userId);
+    res.status(200).json({ success: true, data: groups });
+  } catch (error) {
+    console.error('Get Groups Error:', error);
+    res.status(500).json({ success: false, message: 'Internal Server Error' });
+  }
+};

--- a/src/models/Group.ts
+++ b/src/models/Group.ts
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+const groupSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    groupName: {
+      type: String,
+      require: true,
+    },
+    groupDescription: {
+      type: String,
+    },
+    groupAdministrator: {
+      type: String,
+    },
+  },
+  { timestamps: true }
+);
+
+export const Group = mongoose.model('Group', groupSchema);

--- a/src/routes/groupRoutes.ts
+++ b/src/routes/groupRoutes.ts
@@ -1,0 +1,100 @@
+import { Router } from 'express';
+import { createGroup, getGroups } from '../controllers/groupController';
+import { authMiddleware } from '../middlewares/authMiddleware';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Groups
+ *   description: Group management
+ */
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Group:
+ *       type: object
+ *       properties:
+ *         _id:
+ *           type: string
+ *         userId:
+ *           type: string
+ *         groupName:
+ *           type: string
+ *         groupDescription:
+ *           type: string
+ *         groupAdministrator:
+ *           type: string
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *     GroupInput:
+ *       type: object
+ *       required:
+ *         - groupName
+ *       properties:
+ *         groupName:
+ *           type: string
+ *         groupDescription:
+ *           type: string
+ *         groupAdministrator:
+ *           type: string
+ */
+
+/**
+ * @swagger
+ * /api/v1/groups:
+ *   post:
+ *     summary: Create a new group
+ *     tags: [Groups]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/GroupInput'
+ *     responses:
+ *       201:
+ *         description: Group created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Group'
+ *       400:
+ *         description: Group name is required
+ *       401:
+ *         description: Unauthorized
+ */
+router.post('/', authMiddleware, createGroup);
+
+/**
+ * @swagger
+ * /api/v1/groups:
+ *   get:
+ *     summary: Get all groups for the logged-in user
+ *     tags: [Groups]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of groups
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Group'
+ *       401:
+ *         description: Unauthorized
+ */
+router.get('/', authMiddleware, getGroups);
+
+export default router;

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -1,0 +1,9 @@
+import { Group } from '../models/Group';
+
+export const createGroup = async (data: any, userId: string) => {
+  return Group.create({ ...data, userId });
+};
+
+export const getGroups = async (userId: string) => {
+  return Group.find({ userId });
+};


### PR DESCRIPTION
Implemented backend API endpoints for **Group** resource, including:

* **Create Group** (`POST /api/v1/groups`)
  Allows authenticated users to create new groups by providing a group name, optional description, and administrator name.
  Includes validation for required fields and proper error handling.

* **Get Groups** (`GET /api/v1/groups`)
  Retrieves all groups created by the authenticated user.

* **Authentication middleware** applied to protect the routes.

* Added **Swagger/OpenAPI documentation** for both endpoints to enable easy API exploration and testing.

This feature enables basic group management functionality, laying the foundation for future enhancements such as updating and deleting groups, and assigning group members.


